### PR TITLE
Upgrade to mongoose 4.1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 npm-debug.log
 
 .jshintrc
+
+.idea/

--- a/index.js
+++ b/index.js
@@ -389,7 +389,15 @@
         }
         for (var field in decryptedObject) {
           decipheredVal = decryptedObject[field];
-          this[field] = decipheredVal;
+
+          //JSON.parse returns {type: "Buffer", data: Buffer} for Buffers
+          //https://nodejs.org/api/buffer.html#buffer_buf_tojson
+          if(_.isObject(decipheredVal) && decipheredVal.type === "Buffer"){
+            this[field] = decipheredVal.data;
+          }else {
+            this[field] = decipheredVal;
+          }
+
         }
         this._ct = undefined;
       }

--- a/index.js
+++ b/index.js
@@ -459,6 +459,11 @@
   // which could otherwise cause data loss if validation error fixed and a resave was attempted
   // For use in conjunction with the main encryption plugin
   module.exports.encryptedChildren = function(schema, options) {
+    if (mongoose.version > '4.1.0') {
+      console.warn('encryptedChildren plugin is not needed for mongoose versions above 4.1.1, continuing without plugin.');
+      return;
+    }
+
     schema.post('validate', function(doc) {
       if (doc.errors) {
         decryptEmbeddedDocs(doc);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "dotty": "0.0.2",
-    "mongoose": "~4.0.x",
+    "mongoose": "~4.1.x",
     "underscore": "1.5.x",
     "buffer-equal-constant-time": "1.0.1",
     "json-stable-stringify": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "MIT",
   "dependencies": {
     "dotty": "0.0.2",
-    "mongoose": "3.8.x",
+    "mongoose": "~4.0.x",
     "underscore": "1.5.x",
     "buffer-equal-constant-time": "1.0.1",
     "json-stable-stringify": "1.0.0",
@@ -44,6 +44,6 @@
     "node": ">= 0.10.25"
   },
   "scripts": {
-    "test": "mocha ./test --compilers coffee:coffee-script/register --timeout 3000"
+      "test": "mocha ./test --compilers coffee:coffee-script/register --timeout 3000"
   }
 }

--- a/test/encrypt.coffee
+++ b/test/encrypt.coffee
@@ -1020,12 +1020,10 @@ describe 'Array EmbeddedDocument', ->
       @ParentModel2 = mongoose.model 'ParentWithoutPlugin', ParentModelSchema
       @ChildModel2 = mongoose.model 'ChildAgain', ChildModelSchema
 
-      @mongooseVersion = parseInt(mongoose.version.split('.')[0])
-
-    describe 'in mongoose v3.x', ->
+    describe 'in mongoose prior to v4.1.1', ->
 
       it 'should return encrypted embedded documents', (done) ->
-        return done() if @mongooseVersion > 3
+        return done() if mongoose.version > '4.1.0'
 
         doc = new @ParentModel2
           text: 'here it is'
@@ -1041,10 +1039,10 @@ describe 'Array EmbeddedDocument', ->
           assert.notProperty doc.children[0], 'text'
           done()
 
-    describe 'in mongoose v4.x', ->
+    describe 'in mongoose v4.1.1 and after', ->
 
       it 'should return unencrypted embedded documents after failed parent save', (done) ->
-        return done() if @mongooseVersion < 4
+        return done() if mongoose.version < '4.1.1'
 
         doc = new @ParentModel2
           text: 'here it is'
@@ -1061,6 +1059,7 @@ describe 'Array EmbeddedDocument', ->
           done()
 
   describe 'Encrypted embedded document when parent has validation error and has encryptedChildren plugin', ->
+
     before ->
       ChildModelSchema = mongoose.Schema
         text: type: String
@@ -1069,32 +1068,73 @@ describe 'Array EmbeddedDocument', ->
         encryptionKey: encryptionKey, signingKey: signingKey
         encryptedFields: ['text']
 
-      ParentModelSchema = mongoose.Schema
+      @ParentModelSchema = mongoose.Schema
         text: type: String
         children: [ChildModelSchema]
 
-      ParentModelSchema.pre 'validate', (next) ->
+      @ParentModelSchema.pre 'validate', (next) ->
           @invalidate 'text', 'invalid', this.text
           next()
 
-      ParentModelSchema.plugin encrypt.encryptedChildren
+      @sandbox = sinon.sandbox.create()
+      @sandbox.stub console, 'warn'
+      @sandbox.spy @ParentModelSchema, 'post'
 
+      @ParentModelSchema.plugin encrypt.encryptedChildren
 
-      @ParentModel2 = mongoose.model 'ParentWithPlugin', ParentModelSchema
+      @ParentModel2 = mongoose.model 'ParentWithPlugin', @ParentModelSchema
       @ChildModel2 = mongoose.model 'ChildOnceMore', ChildModelSchema
 
-    it 'should return unencrypted embedded documents after failed parent save', (done) ->
-      doc = new @ParentModel2
-        text: 'here it is'
-        children: [{text: 'Child unencrypted text'}]
-      doc.save (err) ->
-        assert.ok err, 'There should be a validation error'
-        assert.propertyVal doc, 'text', 'here it is'
-        assert.isArray doc.children
-        assert.property doc.children[0], '_id'
-        assert.notProperty doc.children[0], '_ct'
-        assert.property doc.children[0], 'text', 'Child unencrypted text'
-        done()
+    after ->
+      @sandbox.restore()
+
+    describe 'in mongoose prior to v4.1.1', ->
+
+      it 'adds the plugin', ->
+        return if mongoose.version > '4.1.0'
+
+        assert.strictEqual console.warn.callCount, 0
+        assert.strictEqual @ParentModelSchema.post.callCount, 1
+        assert.strictEqual @ParentModelSchema.post.firstCall.args[0], 'validate'
+
+      it 'should return unencrypted embedded documents', (done) ->
+        return done() if mongoose.version > '4.1.0'
+
+        doc = new @ParentModel2
+          text: 'here it is'
+          children: [{text: 'Child unencrypted text'}]
+        doc.save (err) ->
+          assert.ok err, 'There should be a validation error'
+          assert.propertyVal doc, 'text', 'here it is'
+          assert.isArray doc.children
+          assert.property doc.children[0], '_id'
+          assert.notProperty doc.children[0], '_ct'
+          assert.property doc.children[0], 'text', 'Child unencrypted text'
+          done()
+
+    describe 'in mongoose v4.1.1 and after', ->
+
+      it 'should abort adding encryptedChildren plugin', ->
+        return if mongoose.version < '4.1.1'
+
+        assert.strictEqual console.warn.callCount, 1
+        assert.strictEqual console.warn.firstCall.args[0], 'encryptedChildren plugin is not needed for mongoose versions above 4.1.1, continuing without plugin.'
+        assert.strictEqual @ParentModelSchema.post.callCount, 0
+
+      it 'should return unencrypted embedded documents', (done) ->
+        return done() if mongoose.version < '4.1.1'
+
+        doc = new @ParentModel2
+          text: 'here it is'
+          children: [{text: 'Child unencrypted text'}]
+        doc.save (err) ->
+          assert.ok err, 'There should be a validation error'
+          assert.propertyVal doc, 'text', 'here it is'
+          assert.isArray doc.children
+          assert.property doc.children[0], '_id'
+          assert.notProperty doc.children[0], '_ct'
+          assert.property doc.children[0], 'text', 'Child unencrypted text'
+          done()
 
   describe 'Encrypted embedded document when parent has both encrypt and encryptedChildren plugins', ->
     before ->

--- a/test/encrypt.coffee
+++ b/test/encrypt.coffee
@@ -113,7 +113,7 @@ describe 'document.save()', ->
       mix: { str: 'A string', bool: false }
       buf: new Buffer 'abcdefg'
 
-    @simpleTestDoc2.save (err) ->
+    @simpleTestDoc2.save (err) =>
       assert.equal err, null
       done()
 
@@ -909,16 +909,19 @@ describe 'Array EmbeddedDocument', ->
           _id: @parentDoc._id
           'children._ct': $exists: true
           'children.text': $exists: false
-        , (err, docs) ->
-          assert.equal err, null
+        .exec()
+        .then (docs) ->
           assert.lengthOf docs, 1
           assert.propertyVal docs[0].children[0], 'text', 'Child unencrypted text'
           done()
+        , done
+        .end()
 
     describe 'document.find()', ->
       it 'when parent doc found, should pass an unencrypted version of the embedded document to the callback', (done) ->
-        @ParentModel.findById @parentDoc._id, (err, doc) ->
-          assert.equal err, null
+        @ParentModel.findById @parentDoc._id
+        .exec()
+        .then (doc) ->
           assert.propertyVal doc, 'text', 'Unencrypted text'
           assert.isArray doc.children
           assert.isObject doc.children[0]
@@ -926,7 +929,8 @@ describe 'Array EmbeddedDocument', ->
           assert.property doc.children[0], '_id'
           assert.notProperty doc.children[0], '_ct'
           done()
-
+        , done
+        .end()
 
     describe 'when child field is in additionalAuthenticatedFields on parent and child documents are tampered with by swapping their ciphertext', ->
       it 'should pass an error', (done) ->
@@ -1010,25 +1014,51 @@ describe 'Array EmbeddedDocument', ->
         children: [ChildModelSchema]
 
       ParentModelSchema.pre 'validate', (next) ->
-          @invalidate 'text', 'invalid', this.text
-          next()
+        @invalidate 'text', 'invalid', this.text
+        next()
 
       @ParentModel2 = mongoose.model 'ParentWithoutPlugin', ParentModelSchema
       @ChildModel2 = mongoose.model 'ChildAgain', ChildModelSchema
 
-    it 'Should return encrypted embedded documents after failed parent save', (done) ->
-      doc = new @ParentModel2
-        text: 'here it is'
-        children: [{text: 'Child unencrypted text'}]
-      doc.save (err) ->
-        assert.ok err, 'There should be a validation error'
-        assert.propertyVal doc, 'text', 'here it is'
-        assert.isArray doc.children
-        assert.isObject doc.children[0]
-        assert.property doc.children[0], '_id'
-        assert.property doc.children[0], '_ct'
-        assert.notProperty doc.children[0], 'text'
-        done()
+      @mongooseVersion = parseInt(mongoose.version.split('.')[0])
+
+    describe 'in mongoose v3.x', ->
+
+      it 'should return encrypted embedded documents', (done) ->
+        return done() if @mongooseVersion > 3
+
+        doc = new @ParentModel2
+          text: 'here it is'
+          children: [{text: 'Child unencrypted text'}]
+
+        doc.save (err) ->
+          assert.ok err, 'There should be a validation error'
+          assert.propertyVal doc, 'text', 'here it is'
+          assert.isArray doc.children
+          assert.isObject doc.children[0]
+          assert.property doc.children[0], '_id'
+          assert.property doc.children[0], '_ct'
+          assert.notProperty doc.children[0], 'text'
+          done()
+
+    describe 'in mongoose v4.x', ->
+
+      it 'should return unencrypted embedded documents after failed parent save', (done) ->
+        return done() if @mongooseVersion < 4
+
+        doc = new @ParentModel2
+          text: 'here it is'
+          children: [{text: 'Child unencrypted text'}]
+
+        doc.save (err) ->
+          assert.ok err, 'There should be a validation error'
+          assert.propertyVal doc, 'text', 'here it is'
+          assert.isArray doc.children
+          assert.isObject doc.children[0]
+          assert.property doc.children[0], '_id'
+          assert.notProperty doc.children[0], '_ct'
+          assert.property doc.children[0], 'text', 'Child unencrypted text'
+          done()
 
   describe 'Encrypted embedded document when parent has validation error and has encryptedChildren plugin', ->
     before ->
@@ -1403,9 +1433,10 @@ describe 'Tampering with an encrypted document', ->
     BasicEncryptedModel.findOne(_id: @testDoc2._id).lean().exec (err, doc2) =>
       assert.equal err, null
       ctForSwap = doc2._ct.buffer
-      BasicEncryptedModel.update({_id: @testDoc._id}, {$set: _ct: doc2._ct}).exec (err, num) =>
+      BasicEncryptedModel.update({_id: @testDoc._id}, {$set: _ct: doc2._ct}).exec (err, raw) =>
+        n = raw.n || raw
         assert.equal err, null
-        assert.equal num, 1
+        assert.equal n, 1
         BasicEncryptedModel.findOne(_id: @testDoc._id).exec (err, doc) =>
           assert.ok err
           done()
@@ -1448,18 +1479,20 @@ describe 'additionalAuthenticatedFields option', ->
       done()
 
   it 'find should succeed if non-authenticated field is modified directly', (done) ->
-    AuthenticatedFieldsModel.update({_id: @testDocAF._id}, {$set: num: 48}).exec (err, num) =>
+    AuthenticatedFieldsModel.update({_id: @testDocAF._id}, {$set: num: 48}).exec (err, raw) =>
+      n = raw.n || raw
       assert.equal err, null
-      assert.equal num, 1
+      assert.equal n, 1
       AuthenticatedFieldsModel.findById @testDocAF._id, (err, doc) =>
         assert.equal err, null
         assert.propertyVal doc, 'num', 48
         done()
 
   it 'find should fail if non-authenticated field is modified directly', (done) ->
-    AuthenticatedFieldsModel.update({_id: @testDocAF._id}, {$set: bool: false}).exec (err, num) =>
+    AuthenticatedFieldsModel.update({_id: @testDocAF._id}, {$set: bool: false}).exec (err, raw) =>
+      n = raw.n || raw
       assert.equal err, null
-      assert.equal num, 1
+      assert.equal n, 1
       AuthenticatedFieldsModel.findById @testDocAF._id, (err, doc) =>
         assert.ok err, 'There was an error'
         assert.propertyVal err, 'message', 'Authentication failed'
@@ -1489,8 +1522,9 @@ describe '"requireAuthenticationCode" option', ->
         bool: false
         num: 33
 
-      LessSecureModel.collection.insert [plainDoc, plainDoc2], (err, docs) =>
+      LessSecureModel.collection.insert [plainDoc, plainDoc2], (err, raw) =>
         assert.equal err, null
+        docs = raw.ops || raw
         @docId = docs[0]._id
         @doc2Id = docs[1]._id
         done()
@@ -1625,8 +1659,9 @@ describe 'migrations', ->
           _ct: bufferEncryptedWithOldVersion2
           unencryptedText: 'Never was encrypted'
 
-        OriginalModel.collection.insert [docEncryptedWithOldVersion, docEncryptedWithOldVersion2], (err, docs) =>
+        OriginalModel.collection.insert [docEncryptedWithOldVersion, docEncryptedWithOldVersion2], (err, raw) =>
           assert.equal err, null
+          docs = raw.ops || raw
           @docId = docs[0]._id
           @doc2Id = docs[1]._id
           OriginalModel.findById @docId, (err, doc) ->
@@ -1693,8 +1728,9 @@ describe 'migrations', ->
           bool: false
           num: 33
 
-        PreviouslyUnencryptedModel.collection.insert [plainDoc, plainDoc2], (err, docs) =>
+        PreviouslyUnencryptedModel.collection.insert [plainDoc, plainDoc2], (err, raw) =>
           assert.equal err, null
+          docs = raw.ops || raw
           @docId = docs[0]._id
           @doc2Id = docs[1]._id
           done()
@@ -1785,8 +1821,9 @@ describe 'migrations', ->
             { _ct: bufferEncryptedWithOldVersion2, _id: new mongoose.Types.ObjectId() }
            ]
 
-        @OriginalParentModel.collection.insert [docWithChildrenFromOldVersion], (err, docs) =>
+        @OriginalParentModel.collection.insert [docWithChildrenFromOldVersion], (err, raw) =>
           assert.equal err, null
+          docs = raw.ops || raw
           @docId = docs[0]._id
           done()
 
@@ -1841,8 +1878,9 @@ describe 'migrations', ->
         bool: false
         num: 33
 
-      UnsignedModel.collection.insert [plainDoc, plainDoc2], (err, docs) =>
+      UnsignedModel.collection.insert [plainDoc, plainDoc2], (err, raw) =>
         assert.equal err, null
+        docs = raw.ops || raw
         @docId = docs[0]._id
         @doc2Id = docs[1]._id
         done()


### PR DESCRIPTION
~~This is **not ready to merge**, we need to wait for https://github.com/Automattic/mongoose/pull/3220 to be merged and a version bump on mongoose. Figured I would go ahead and open this so you can see what I did though.~~ Turns out all the source change was mongoose side. All I did was update tests to work with either mongoose 3 or 4. I have been running them with both versions locally. It may be helpful to setup 2 TravisCi pipelines, one for each version, so functionality is ensured in both of them. I also stop the `encryptedChildren` plugin from loading in mongoose versions past `4.1.1` because it isn't needed.

I included @wlingke's commit from his PR because it fixed a group of tests. If you merge his PR separately, I can fix the merge conflict. Up to you.

closes #12 