### PR TITLE
doc._ac should not exist after saving a document

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,6 +392,7 @@
           this[field] = decipheredVal;
         }
         this._ct = undefined;
+        this._ac = undefined;
       }
     };
 
@@ -435,10 +436,7 @@
       var expectedHMAC = computeAC(this, authenticatedFieldsUsed, versionUsed, arguments[0]); // pass in modelName as argument in init hook
 
       var authentic = bufferEqual(basicAC, expectedHMAC);
-      if (authentic){
-        this._ac = undefined;
-        return null;
-      } else {
+      if (!authentic){
         throw new Error('Authentication failed');
       }
     };

--- a/test/encrypt.coffee
+++ b/test/encrypt.coffee
@@ -141,15 +141,22 @@ describe 'document.save()', ->
 
   it 'returns decrypted data after save', (done) ->
     @simpleTestDoc2.save (err, doc) ->
-      assert.equal doc.text, 'Unencrypted text'
-      assert.equal doc.bool, true
-      assert.equal doc.num, 42
-      assert.deepEqual doc.date, new Date('2014-05-19T16:39:07.536Z')
-      assert.equal doc.id2, '5303e65d34e1e80d7a7ce212'
-      assert.equal doc.arr.toString(), ['alpha', 'bravo'].toString()
-      assert.deepEqual doc.mix, { str: 'A string', bool: false }
-      assert.deepEqual doc.buf, new Buffer 'abcdefg'
-      done err
+      return done(err) if err
+
+      try
+        assert.equal doc._ct, undefined
+        assert.equal doc._ac, undefined
+        assert.equal doc.text, 'Unencrypted text'
+        assert.equal doc.bool, true
+        assert.equal doc.num, 42
+        assert.deepEqual doc.date, new Date('2014-05-19T16:39:07.536Z')
+        assert.equal doc.id2, '5303e65d34e1e80d7a7ce212'
+        assert.equal doc.arr.toString(), ['alpha', 'bravo'].toString()
+        assert.deepEqual doc.mix, { str: 'A string', bool: false }
+        assert.deepEqual doc.buf, new Buffer 'abcdefg'
+        done()
+      catch err
+        done err
 
    it 'should have called encryptSync then authenticateSync then decryptSynd', ->
     assert.equal @simpleTestDoc2.sign.callCount, 1


### PR DESCRIPTION
There is a `post-save` hook that decrypts the document so you can keep working with it; however, `doc._ac` is removed in `authenticateSync` which doesn't happen `post-save`. Removing `doc._ac` at decrypt time instead of authenticate time offers the same functionality but with the added benefit of it not being on the document after it is saved.