### PR TITLE
Bug fix: DocumentArray #addToSet and #remove should not break authentication

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,6 +269,7 @@
               throw err; // note: this won't actually get thrown until save, because errors in subdoc init fns are CastErrors and aren't thrown by validate()
             }
             this._doc = data;
+            next();
             return this;
           } else {
             return next(err);


### PR DESCRIPTION
@joegoldbeck, after adding or removing a child from a subcollection, we are getting an "Authentication Failed" error. I have spent a little bit of time trying to figure out why, but it is eluding me. These tests reproduce the behavior, do you have any thoughts on what might be happening?