### PR TITLE
Make peerDependencies dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,10 @@
     "async": "0.9.0",
     "buffer-equal-constant-time": "1.0.1",
     "dotty": "0.0.2",
+    "mongoose": ">=3.8.28",
     "mpath": "0.2.1",
     "json-stable-stringify": "1.0.0",
-    "semver": "5.1.x"
-  },
-  "peerDependencies":{
-    "mongoose": ">=3.8.28",
+    "semver": "5.1.x",
     "underscore": ">=1.5.0 <2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In `npm@3`, `peerDependencies` are deprecated. This moves the `peerDependencies` to `dependencies`.

Previously, one would assume `mongooose` was already installed 😉 , but requiring this library would fail without underscore, and this module would not install underscore using `npm@3`