### PR TITLE
Fixed problem with Mongoose 5 'init' in mongoose-encryption.js

### DIFF
--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -237,6 +237,11 @@ var mongooseEncryption = function(schema, options) {
 
     if (options.middleware) { // defaults to true
         schema.pre('init', function(next, data) {
+            if (!(next instanceof Function)) {
+                data = next
+                next = function() {}
+            }
+            
             var err = null;
             try { // this hook must be synchronous for embedded docs, so everything is synchronous for code simplicity
                 if (!isEmbeddedDocument(this)){ // don't authenticate embedded docs because there's no way to handle the error appropriately


### PR DESCRIPTION
Fixed issue related to the switch from asynchronous to synchronous execution of `init` in [`lib/plugins/mongoose-encryption.js`](https://github.com/joegoldbeck/mongoose-encryption/blob/master/lib/plugins/mongoose-encryption.js#L239) (line 239) in response to issue #70. It's a quick and possibly dirty solution, but it works.