### PR TITLE
Update mpath dependency to v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "async": "^2.6.1",
     "buffer-equal-constant-time": "^1.0.1",
     "dotty": "~0.1.0",
-    "mpath": "~0.4.1",
     "json-stable-stringify": "^1.0.0",
+    "mpath": "^0.5.1",
     "semver": "^5.5.0",
     "underscore": "^1.5.0"
   },
-  "peerDependencies":{
+  "peerDependencies": {
     "mongoose": ">=5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #84 (https://www.npmjs.com/advisories/779)
There's one breaking change but it should not affect this lib:
https://github.com/aheckmann/mpath/blob/0.5.1/History.md
