### PR TITLE
Add TypeScript type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,54 +1,57 @@
 {
-  "name": "mongoose-encryption",
-  "description": "Simple encryption and authentication plugin for Mongoose",
-  "version": "2.0.2",
-  "author": {
-    "name": "Joe Goldbeck"
-  },
-  "keywords": [
-    "mongoose",
-    "mongo",
-    "encrypt",
-    "encryption",
-    "sign",
-    "authenticate",
-    "authentication",
-    "mongodb",
-    "HMAC"
-  ],
-  "main": "./index.js",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/joegoldbeck/mongoose-encryption.git"
-  },
-  "bugs": {
-    "url": "https://github.com/joegoldbeck/mongoose-encryption/issues"
-  },
-  "homepage": "https://github.com/joegoldbeck/mongoose-encryption",
-  "license": "MIT",
-  "dependencies": {
-    "async": "^2.6.1",
-    "buffer-equal-constant-time": "^1.0.1",
-    "dotty": "~0.1.0",
-    "json-stable-stringify": "^1.0.0",
-    "mpath": "^0.5.1",
-    "semver": "^5.5.0",
-    "underscore": "^1.5.0"
-  },
-  "peerDependencies": {
-    "mongoose": ">=5.0.0"
-  },
-  "devDependencies": {
-    "mocha": "^1.0.0",
-    "mongoose": ">=5.0.0",
-    "chai": "^1.0.0",
-    "coffeescript": "^1.7.0",
-    "sinon": "^1.10.3"
-  },
-  "engines": {
-    "node": ">=4.4.5"
-  },
-  "scripts": {
-    "test": "mocha ./test --compilers coffee:coffeescript/register --timeout 3000"
-  }
+    "name": "mongoose-encryption",
+    "description": "Simple encryption and authentication plugin for Mongoose",
+    "version": "2.0.2",
+    "author": {
+        "name": "Joe Goldbeck"
+    },
+    "keywords": [
+        "mongoose",
+        "mongo",
+        "encrypt",
+        "encryption",
+        "sign",
+        "authenticate",
+        "authentication",
+        "mongodb",
+        "HMAC"
+    ],
+    "main": "./index.js",
+    "types": "./types/index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/joegoldbeck/mongoose-encryption.git"
+    },
+    "bugs": {
+        "url": "https://github.com/joegoldbeck/mongoose-encryption/issues"
+    },
+    "homepage": "https://github.com/joegoldbeck/mongoose-encryption",
+    "license": "MIT",
+    "dependencies": {
+        "async": "^2.6.1",
+        "buffer-equal-constant-time": "^1.0.1",
+        "dotty": "~0.1.0",
+        "json-stable-stringify": "^1.0.0",
+        "mpath": "^0.5.1",
+        "semver": "^5.5.0",
+        "underscore": "^1.5.0"
+    },
+    "peerDependencies": {
+        "mongoose": ">=5.0.0"
+    },
+    "devDependencies": {
+        "chai": "^1.0.0",
+        "coffeescript": "^1.7.0",
+        "mocha": "^1.0.0",
+        "mongoose": ">=5.0.0",
+        "sinon": "^1.10.3",
+        "typescript": "^4.1.2"
+    },
+    "engines": {
+        "node": ">=4.4.5"
+    },
+    "scripts": {
+        "test": "mocha ./test --compilers coffee:coffeescript/register --timeout 3000",
+        "build-ts": "tsc"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,57 +1,57 @@
 {
-    "name": "mongoose-encryption",
-    "description": "Simple encryption and authentication plugin for Mongoose",
-    "version": "2.0.2",
-    "author": {
-        "name": "Joe Goldbeck"
-    },
-    "keywords": [
-        "mongoose",
-        "mongo",
-        "encrypt",
-        "encryption",
-        "sign",
-        "authenticate",
-        "authentication",
-        "mongodb",
-        "HMAC"
-    ],
-    "main": "./index.js",
-    "types": "./types/index.d.ts",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/joegoldbeck/mongoose-encryption.git"
-    },
-    "bugs": {
-        "url": "https://github.com/joegoldbeck/mongoose-encryption/issues"
-    },
-    "homepage": "https://github.com/joegoldbeck/mongoose-encryption",
-    "license": "MIT",
-    "dependencies": {
-        "async": "^2.6.1",
-        "buffer-equal-constant-time": "^1.0.1",
-        "dotty": "~0.1.0",
-        "json-stable-stringify": "^1.0.0",
-        "mpath": "^0.5.1",
-        "semver": "^5.5.0",
-        "underscore": "^1.5.0"
-    },
-    "peerDependencies": {
-        "mongoose": ">=5.0.0"
-    },
-    "devDependencies": {
-        "chai": "^1.0.0",
-        "coffeescript": "^1.7.0",
-        "mocha": "^1.0.0",
-        "mongoose": ">=5.0.0",
-        "sinon": "^1.10.3",
-        "typescript": "^4.1.2"
-    },
-    "engines": {
-        "node": ">=4.4.5"
-    },
-    "scripts": {
-        "test": "mocha ./test --compilers coffee:coffeescript/register --timeout 3000",
-        "build-ts": "tsc"
-    }
+  "name": "mongoose-encryption",
+  "description": "Simple encryption and authentication plugin for Mongoose",
+  "version": "2.0.2",
+  "author": {
+    "name": "Joe Goldbeck"
+  },
+  "keywords": [
+    "mongoose",
+    "mongo",
+    "encrypt",
+    "encryption",
+    "sign",
+    "authenticate",
+    "authentication",
+    "mongodb",
+    "HMAC"
+  ],
+  "main": "./index.js",
+  "types": "./types/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/joegoldbeck/mongoose-encryption.git"
+  },
+  "bugs": {
+    "url": "https://github.com/joegoldbeck/mongoose-encryption/issues"
+  },
+  "homepage": "https://github.com/joegoldbeck/mongoose-encryption",
+  "license": "MIT",
+  "dependencies": {
+    "async": "^2.6.1",
+    "buffer-equal-constant-time": "^1.0.1",
+    "dotty": "~0.1.0",
+    "json-stable-stringify": "^1.0.0",
+    "mpath": "^0.5.1",
+    "semver": "^5.5.0",
+    "underscore": "^1.5.0"
+  },
+  "peerDependencies": {
+    "mongoose": ">=5.0.0"
+  },
+  "devDependencies": {
+    "chai": "^1.0.0",
+    "coffeescript": "^1.7.0",
+    "mocha": "^1.0.0",
+    "mongoose": ">=5.0.0",
+    "sinon": "^1.10.3",
+    "typescript": "^4.1.2"
+  },
+  "engines": {
+    "node": ">=4.4.5"
+  },
+  "scripts": {
+    "test": "mocha ./test --compilers coffee:coffeescript/register --timeout 3000",
+    "build-ts": "tsc"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "include": ["index.js", "lib/**/*"],
+    "compilerOptions": {
+        "allowJs": true,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "types"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
-    "include": ["index.js", "lib/**/*"],
-    "compilerOptions": {
-        "allowJs": true,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "outDir": "types"
-    }
+  "include": ["index.js", "lib/**/*"],
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types"
+  }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,16 @@
+declare function _exports(schema: any, options: {
+    secret?: string;
+    encryptionKey?: string;
+    signingKey?: string;
+    encryptedFields?: string[];
+    excludeFromEncryption?: string[];
+    additionalAuthenticatedFields?: string[];
+    requireAuthenticationCode?: boolean;
+    decryptPostSave?: boolean;
+    collectionId?: string;
+}): undefined;
+declare namespace _exports {
+    const encryptedChildren: (schema: any) => void;
+    const migrations: (schema: any, options: any) => void;
+}
+export = _exports;

--- a/types/lib/plugins/encrypted-children.d.ts
+++ b/types/lib/plugins/encrypted-children.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(schema: any): void;
+export = _exports;

--- a/types/lib/plugins/migrations.d.ts
+++ b/types/lib/plugins/migrations.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(schema: any, options: any): void;
+export = _exports;

--- a/types/lib/plugins/mongoose-encryption.d.ts
+++ b/types/lib/plugins/mongoose-encryption.d.ts
@@ -1,0 +1,35 @@
+export = mongooseEncryption;
+/**
+ * Mongoose encryption plugin
+ * @module mongoose-encryption
+ *
+ *
+ * @param      {Object}     schema   The schema
+ * @param      {Object}     options  Plugin options
+ * @param      {string}     [options.secret]  A secret string which will be used to generate an encryption key and a signing key
+ * @param      {string}     [options.encryptionKey]  A secret string which will be used to generate an encryption key
+ * @param      {string}     [options.signingKey]  A secret string which will be used to generate a signing key
+ * @param      {string[]}   [options.encryptedFields]  A list of fields to encrypt. Default is to encrypt all fields.
+ * @param      {string[]}   [options.excludeFromEncryption]  A list of fields to not encrypt
+ * @param      {string[]}   [options.additionalAuthenticatedFields]  A list of fields to authenticate even if they aren't encrypted
+ * @param      {boolean}    [options.requireAuthenticationCode=true]  Whether documents without an authentication code are valid
+ * @param      {boolean}    [options.decryptPostSave=true]  Whether to automatically decrypt documents in the application after saving them (faster if false)
+ * @param      {string}     [options.collectionId]  If you update the Model name of the schema, this should be set to its original name
+ * @return     {undefined}
+ */
+declare function mongooseEncryption(schema: any, options: {
+    secret: string;
+    encryptionKey: string;
+    signingKey: string;
+    encryptedFields: string[];
+    excludeFromEncryption: string[];
+    additionalAuthenticatedFields: string[];
+    requireAuthenticationCode: boolean;
+    decryptPostSave: boolean;
+    collectionId: string;
+}): undefined;
+declare namespace mongooseEncryption {
+    export { AAC_LENGTH, VERSION_LENGTH };
+}
+declare var AAC_LENGTH: number;
+declare var VERSION_LENGTH: number;

--- a/types/lib/util/crypto-util.d.ts
+++ b/types/lib/util/crypto-util.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Derives 512 bit key from a string secret
+ *
+ * @param      {string}  secret  The secret
+ * @param      {string}  type    The type of key to generate. Can be any string.
+ * @return     {Buffer}  512 bit key
+ */
+export function deriveKey(secret: string, type: string): any;
+/**
+ * Utility function: Zeros a buffer for security
+ *
+ * @param      {Buffer}  buf     The buffer
+ */
+export function clearBuffer(buf: any): void;
+/**
+ * Drops 256 bits from a 512 bit buffer
+ *
+ * @param      {Buffer}  buf     A 512 bit buffer
+ * @return     {Buffer}  A 256 bit buffer
+ */
+export function drop256(buf: any): any;

--- a/types/lib/util/decryptEmbeddedDocs.d.ts
+++ b/types/lib/util/decryptEmbeddedDocs.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(doc: any): void;
+export = _exports;

--- a/types/lib/util/object-util.d.ts
+++ b/types/lib/util/object-util.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Sets the value of a field.
+ *
+ * @param      {Object}  obj     The object
+ * @param      {string}  field   The path to a field. Can include dots (.)
+ * @param      {*}       val     The value to set the field
+ * @return     {Object}  The modified object
+ */
+export function setFieldValue(obj: any, field: string, val: any): any;
+/**
+ * Pick a subset of fields from an object
+ *
+ * @param      {Object}   obj      The object
+ * @param      {string[]} fields   The fields to pick. Can include dots (.)
+ * @param      {Object}   [options]  The options
+ * @param      {boolean}  [options.excludeUndefinedValues=false]  Whether undefined values should be included in returned object.
+ * @return     {Object}   An object containing only those fields that have been picked
+ */
+export function pick(obj: any, fields: string[], options?: {
+    excludeUndefinedValues: boolean;
+}): any;
+/**
+ * Determines if embedded document.
+ *
+ * @param      {Model}    doc     The Mongoose document
+ * @return     {boolean}  True if embedded document, False otherwise.
+ */
+export function isEmbeddedDocument(doc: any): boolean;


### PR DESCRIPTION
This PR adds automatically generated TS type declaration files (fixes #93).
These are automatically generated using the JSDoc annotations in the code, but most of the types just end up being declared as `any`. This doesn't really matter, since the actual functions won't get called by typescript code anyway and is mostly just to get rid of the error from not having them.
These can be generated by just running `tsc` (the TS compiler), or `npm run build-ts` with the dev dependencies installed.
I can go through and manually make a proper type declaration if you'd like, but again, this code doesn't get directly called anyway, so it shouldn't matter.

Let me know what you think!