### PR TITLE
update to support node 15.3.0 and large documents

### DIFF
--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -331,17 +331,22 @@ var mongooseEncryption = function(schema, options) {
 
             jsonToEncrypt = JSON.stringify(objectToEncrypt);
 
-            cipher.end(jsonToEncrypt, 'utf-8', function() {
-                // add ciphertext to document
-                that._ct = Buffer.concat([VERSION_BUF, iv, cipher.read()]);
+            cipher.write(jsonToEncrypt);
+            cipher.end();
 
-                // remove encrypted fields from cleartext
-                encryptedFields.forEach(function(field){
-                    setFieldValue(that, field, undefined);
-                });
+            var chunk, chunks = [];
+            while ((chunk = cipher.read()) !== null) chunks.push(chunk);
+            var encrypted = Buffer.concat(chunks);
 
-                cb(null);
+            // add ciphertext to document
+            that._ct = Buffer.concat([VERSION_BUF, iv, Buffer.from(encrypted,'utf8')]);
+
+            // remove encrypted fields from cleartext
+            encryptedFields.forEach(function(field){
+                setFieldValue(that, field, undefined);
             });
+
+            cb(null);
         });
     };
 


### PR DESCRIPTION
Using node 15.3.0 and saving large json objects the Model.save() method would just wait forever and never finish.
This PR fixes the endless wait and allows saving large JSON objects again.