### PR TITLE
Store encrypted fields list to _ct._cf

### DIFF
--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -418,29 +418,17 @@ var mongooseEncryption = function(schema, options) {
         cb();
     };
 
-    schema.methods.decryptTo = function(data) {
-        var ct, cf, ctWithIV, decipher, iv, idString, decryptedObject, decryptedObjectJSON, decipheredVal;
+    schema.methods.decryptCt = function(_ct) {
+        var ct, ctWithIV, decipher, iv, idString, decryptedObjectJSON;
 
         try {
-            ctWithIV = data._ct.hasOwnProperty('buffer') ? data._ct.buffer : data._ct;
+            ctWithIV = _ct.hasOwnProperty('buffer') ? _ct.buffer : _ct;
             iv = ctWithIV.slice(VERSION_LENGTH, VERSION_LENGTH + IV_LENGTH);
             ct = ctWithIV.slice(VERSION_LENGTH + IV_LENGTH, ctWithIV.length);
     
             decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, encryptionKey, iv);
             decryptedObjectJSON = decipher.update(ct, undefined, 'utf8') + decipher.final('utf8');
-            decryptedObject = JSON.parse(decryptedObjectJSON);
-    
-            if (cfMode === 'require' && !decryptedObject._cf) {
-                throw new Error('Cipher fields _cf is required, but not found');
-            }
-    
-            if (cfMode !== 'disable' &&  decryptedObject._cf) {
-                cf = decryptedObject._cf.split(',');
-            }
-            
-            if (!cf) {
-                cf = encryptedFields;
-            }
+            return JSON.parse(decryptedObjectJSON);
         } catch (err) {
             if (this._id) {
                 idString = this._id.toString();
@@ -449,7 +437,24 @@ var mongooseEncryption = function(schema, options) {
             }
             throw new Error('Error during decrypt of ' + idString + ': ' + err);
         }
+    };
 
+    schema.methods.decryptTo = function(data) {
+        var cf, decryptedObject, decipheredVal;
+
+        decryptedObject = this.decryptCt(data._ct)
+
+        if (cfMode === 'require' && !decryptedObject._cf) {
+            throw new Error('Cipher fields _cf is required, but not found');
+        }
+
+        if (cfMode !== 'disable' &&  decryptedObject._cf) {
+            cf = decryptedObject._cf.split(',');
+        }
+        
+        if (!cf) {
+            cf = encryptedFields;
+        }
 
         cf.forEach(function(field) {
             decipheredVal = mpath.get(field, decryptedObject);

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -116,7 +116,7 @@ var mongooseEncryption = function(schema, options) {
     /** Encryption Options */
 
     if (options.encryptedFields) {
-        encryptedFields = _.sortBy(_.difference(options.encryptedFields, ['_ct']));
+        encryptedFields = _.difference(options.encryptedFields, ['_ct']);
     } else {
         excludedFields = _.union(['_id', '_ct'], options.excludeFromEncryption);
         encryptedFields = _.chain(schema.paths)
@@ -126,7 +126,6 @@ var mongooseEncryption = function(schema, options) {
             .pluck('path') // get path name
             .difference(excludedFields) // exclude excluded fields
             .uniq()
-            .sortBy()
             .value();
     }
 

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -35,6 +35,12 @@ if(semver.lt(mongoose.version, '5.0.0')){
     throw new Error('Mongoose version 5.0.0 or greater is required');
 }
 
+
+/**
+ * @typedef {'store'|'require'|'disable'} CfMode
+ */
+
+
 /**
  * Mongoose encryption plugin
  * @module mongoose-encryption
@@ -51,11 +57,12 @@ if(semver.lt(mongoose.version, '5.0.0')){
  * @param      {boolean}    [options.requireAuthenticationCode=true]  Whether documents without an authentication code are valid
  * @param      {boolean}    [options.decryptPostSave=true]  Whether to automatically decrypt documents in the application after saving them (faster if false)
  * @param      {string}     [options.collectionId]  If you update the Model name of the schema, this should be set to its original name
+ * @param      {CfMode}     [options.cfMode='store']
  * @return     {undefined}
  */
 
 var mongooseEncryption = function(schema, options) {
-    var encryptedFields, excludedFields, authenticatedFields, encryptionKey, signingKey, path;
+    var encryptedFields, excludedFields, authenticatedFields, encryptionKey, signingKey, path, cfMode;
 
     _.defaults(options, {
         middleware: true, // allow for skipping middleware with false
@@ -102,10 +109,14 @@ var mongooseEncryption = function(schema, options) {
     }
 
 
+    /** Decryption Options */
+    cfMode = options.cfMode || 'store';
+
+
     /** Encryption Options */
 
     if (options.encryptedFields) {
-        encryptedFields = _.difference(options.encryptedFields, ['_ct']);
+        encryptedFields = _.sortBy(_.difference(options.encryptedFields, ['_ct']));
     } else {
         excludedFields = _.union(['_id', '_ct'], options.excludeFromEncryption);
         encryptedFields = _.chain(schema.paths)
@@ -115,6 +126,7 @@ var mongooseEncryption = function(schema, options) {
             .pluck('path') // get path name
             .difference(excludedFields) // exclude excluded fields
             .uniq()
+            .sortBy()
             .value();
     }
 
@@ -149,6 +161,9 @@ var mongooseEncryption = function(schema, options) {
         });
     }
 
+    if (cfMode !== 'disable' && schema.paths._cf) {
+        throw new Error('Schema cannot use _cf field when cf is enabled');
+    }
 
 
     /** Authentication Functions */
@@ -243,8 +258,8 @@ var mongooseEncryption = function(schema, options) {
                         }
                     }
                 }
-                if (this.isSelected('_ct')){
-                    this.decryptSync.call(data);
+                if (this.isSelected('_ct') && data._ct){
+                    this.decryptTo(data);
                 }
             } catch (e) {
                 err = e;
@@ -264,6 +279,10 @@ var mongooseEncryption = function(schema, options) {
         schema.pre('save', function(next) {
             var that = this;
             if (this.isNew || this.isSelected('_ct') ){
+                if (this.isNew) {
+                    that._cf = encryptedFields;
+                }
+
                 that.encrypt(function(err){
                     if (err) {
                         next(err);
@@ -321,12 +340,22 @@ var mongooseEncryption = function(schema, options) {
 
         // generate random iv
         crypto.randomBytes(IV_LENGTH, function(err, iv) {
-            var cipher, jsonToEncrypt, objectToEncrypt;
+            var cf, cipher, jsonToEncrypt, objectToEncrypt;
             if (err) {
                 return cb(err);
             }
+
+            if (cfMode === 'disable') {
+                cf = encryptedFields;
+            } else {
+                cf = that._cf || encryptedFields;
+            }
+
             cipher = crypto.createCipheriv(ENCRYPTION_ALGORITHM, encryptionKey, iv);
-            objectToEncrypt = pick(that, encryptedFields, {excludeUndefinedValues: true});
+            objectToEncrypt = pick(that, cf, {excludeUndefinedValues: true});
+            if (cfMode !== 'disable') {
+                objectToEncrypt._cf = cf.join(',');
+            }
 
             jsonToEncrypt = JSON.stringify(objectToEncrypt);
 
@@ -343,13 +372,43 @@ var mongooseEncryption = function(schema, options) {
             that._ct = Buffer.concat([VERSION_BUF, iv, Buffer.from(encrypted, 'utf8')]);
 
             // remove encrypted fields from cleartext
-            encryptedFields.forEach(function(field){
-                setFieldValue(that, field, undefined);
+            cf.forEach(function(field){
+                that.set(field, undefined);
             });
 
             cb(null);
         });
     };
+
+    schema.methods.updateCf = function () {
+        var that = this, extractedFields;
+
+        if(this._ct){
+            return cb(new Error('Cf update failed: document is not deciphered'));
+        }
+
+        extractedFields = _.difference(that._cf, encryptedFields);
+        extractedFields.forEach(field => that.markModified(field));
+
+        that._cf = encryptedFields;
+
+        _.keys(this.schema.paths).forEach(function (path) {
+            if (path === '_id' || path === '__v') {
+                return;
+            }
+    
+            var nestedDoc = dotty.get(that, path);
+            var docs = _.isArray(nestedDoc) ? nestedDoc : [nestedDoc];
+    
+            if (docs && docs[0] && isEmbeddedDocument(docs[0])) {
+                docs.forEach(function (subDoc) {
+                    if (_.isFunction(subDoc.updateCf)) {
+                        subDoc.updateCf();
+                    }
+                });
+            }
+        });
+    }
 
     schema.methods.decrypt = function(cb) { // callback style but actually synchronous to allow for decryptSync without copypasta or complication
         try {
@@ -360,41 +419,62 @@ var mongooseEncryption = function(schema, options) {
         cb();
     };
 
-    schema.methods.decryptSync = function() {
-        var that = this;
-        var ct, ctWithIV, decipher, iv, idString, decryptedObject, decryptedObjectJSON, decipheredVal;
-        if (this._ct) {
-            ctWithIV = this._ct.hasOwnProperty('buffer') ? this._ct.buffer : this._ct;
+    schema.methods.decryptTo = function(data) {
+        var ct, cf, ctWithIV, decipher, iv, idString, decryptedObject, decryptedObjectJSON, decipheredVal;
+
+        try {
+            ctWithIV = data._ct.hasOwnProperty('buffer') ? data._ct.buffer : data._ct;
             iv = ctWithIV.slice(VERSION_LENGTH, VERSION_LENGTH + IV_LENGTH);
             ct = ctWithIV.slice(VERSION_LENGTH + IV_LENGTH, ctWithIV.length);
-
+    
             decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, encryptionKey, iv);
-            try {
-                decryptedObjectJSON = decipher.update(ct, undefined, 'utf8') + decipher.final('utf8');
-                decryptedObject = JSON.parse(decryptedObjectJSON);
-            } catch (err) {
-                if (this._id) {
-                    idString = this._id.toString();
-                } else {
-                    idString = 'unknown';
-                }
-                throw new Error('Error parsing JSON during decrypt of ' + idString + ': ' + err);
+            decryptedObjectJSON = decipher.update(ct, undefined, 'utf8') + decipher.final('utf8');
+            decryptedObject = JSON.parse(decryptedObjectJSON);
+    
+            if (cfMode === 'require' && !decryptedObject._cf) {
+                throw new Error('Cipher fields _cf is required, but not found');
             }
+    
+            if (cfMode !== 'disable' &&  decryptedObject._cf) {
+                cf = decryptedObject._cf.split(',');
+            }
+            
+            if (!cf) {
+                cf = encryptedFields;
+            }
+        } catch (err) {
+            if (this._id) {
+                idString = this._id.toString();
+            } else {
+                idString = 'unknown';
+            }
+            throw new Error('Error during decrypt of ' + idString + ': ' + err);
+        }
 
-            encryptedFields.forEach(function(field) {
-                decipheredVal = mpath.get(field, decryptedObject);
 
-                //JSON.parse returns {type: "Buffer", data: Buffer} for Buffers
-                //https://nodejs.org/api/buffer.html#buffer_buf_tojson
-                if(_.isObject(decipheredVal) && decipheredVal.type === "Buffer"){
-                    setFieldValue(that, field, decipheredVal.data);
-                }else {
-                    setFieldValue(that, field, decipheredVal);
-                }
-            });
+        cf.forEach(function(field) {
+            decipheredVal = mpath.get(field, decryptedObject);
 
-            this._ct = undefined;
-            this._ac = undefined;
+            //JSON.parse returns {type: "Buffer", data: Buffer} for Buffers
+            //https://nodejs.org/api/buffer.html#buffer_buf_tojson
+            if(_.isObject(decipheredVal) && decipheredVal.type === "Buffer"){
+                setFieldValue(data, field, decipheredVal.data);
+            }else {
+                setFieldValue(data, field, decipheredVal);
+            }
+        })
+
+        data._ct = undefined;
+        data._ac = undefined;
+
+        if (cfMode !== 'disable') {
+            this._cf = cf;
+        }
+    };
+
+    schema.methods.decryptSync = function() {
+        if (this._ct) {
+            this.decryptTo(this);
         }
     };
 

--- a/test/encrypt.coffee
+++ b/test/encrypt.coffee
@@ -398,7 +398,7 @@ describe 'EncryptedModel.find()', ->
   before (done) ->
     @sandbox = sinon.sandbox.create()
     @sandbox.spy BasicEncryptedModel.prototype, 'authenticateSync'
-    @sandbox.spy BasicEncryptedModel.prototype, 'decryptSync'
+    @sandbox.spy BasicEncryptedModel.prototype, 'decryptTo'
     simpleTestDoc3 = new BasicEncryptedModel
       text: 'Unencrypted text'
       bool: true
@@ -414,7 +414,7 @@ describe 'EncryptedModel.find()', ->
 
   beforeEach ->
     BasicEncryptedModel.prototype.authenticateSync.reset()
-    BasicEncryptedModel.prototype.decryptSync.reset()
+    BasicEncryptedModel.prototype.decryptTo.reset()
 
   after (done) ->
     @sandbox.restore()
@@ -458,13 +458,13 @@ describe 'EncryptedModel.find()', ->
       done()
     return
 
-  it 'should have called authenticateSync then decryptSync', (done) ->
+  it 'should have called authenticateSync then decryptTo', (done) ->
     BasicEncryptedModel.findById simpleTestDoc3._id, (err, doc) ->
       assert.equal err, null
       assert.ok doc
       assert.equal doc.authenticateSync.callCount, 1
-      assert.equal doc.decryptSync.callCount, 1
-      assert doc.authenticateSync.calledBefore doc.decryptSync, 'authenticated before decrypted'
+      assert.equal doc.decryptTo.callCount, 1
+      assert doc.authenticateSync.calledBefore doc.decryptTo, 'authenticated before decrypted'
       done()
     return
 


### PR DESCRIPTION
### TL;DR

Remember the time when you needed to decrypt an encrypted field? Or maybe you needed to move a field to encryption? 
Remember the pain?

1) Run once:
```
const updateCtAll = async () => {
    for await (const doc of Model.find()) {
        doc.updateCt()
        await doc.save()
    }
}
```

2) Set `cfMode: 'require'` option in plugin configuration

And now you can change schema and plugin options to tweak list of encrypted fields.
Existing records will work transparently, because each record now includes its own list of encrypted fields!

Keep in mind, that existing records keep their lists of encrypted fields. So, updating a record won't automaticaly "reconfigure" its ancryption. But you can call `doc.updateCt()` and record will be reconfigured!

So, if you need to add an index over previously encrypted field (or just decrypt a field), or to encrypt another field, you just do it in schema's config. And when you need to reconfigure existing records, just run something like `updateCtAll` again.

___________________________________________


### PR goals:
1. Protect from data loss caused by changes in encrypted fields list 
2. Provide a way to change encrypted fields list in controlled manner


### Rationale:
Documents are populated from two data sources: "secret" part (stored in `_ct` field), and "exposed" (regular MongoDB fields). Conflicts can happen between the two. Currently there's no way to handle such conflicts, nor any protection from operation on possibly conflicting data.



### Data loss example:
Data loss occurs when schema is changed in a way that affects encrypted fields list, such as adding an index on a field:

```
const Schema1 = new Schema({
    my_data: { type: String },
})

const Schema2 = new Schema({
    my_data: {  type: String, index: true }
})

// Adding index to the Schema2 will lead to exclusion of `my_data` field from `encryptedFields` list.
// Because of that, `my_data` field won't be populated from `_ct` on next instantiation,
// Saving document with non-populated `my_data` field will overwrite `_ct`, and data will be lost.

// Same problem occurs when fields excluded from encryption other ways,
// such as using `excludeFromEncryption` option.
```


### Tests repo:
More detailed examples (ready to run): https://github.com/jenyatra/mongoose-encryption-test
```
git clone https://github.com/jenyatra/mongoose-encryption-test
cd mongoose-encryption-test
npm install
echo "MONGO_URI=mongodb://localhost:27017/$SET YOUR TEST DB HERE$" > .env
```
Available tests:

- `npm run fields_change`: Test changes in encrypted fields list for root fields
- `npm run fields_change:store`: Previous test run by proposed version
- `npm run fields_change_deep`:  Same for nested fields (type: Mixed, dot notation)
- `npm run fields_change_deep:store`:  Previous test run by proposed version
- `npm run fields_change_nested`: Test for nested docs (type: new Schema)
- `npm run fields_change_nested:store`: Previous test run by proposed version
- `npm run init_cf`: Example of _cf initialization on existing data


### Addressing issues on changing decryption fields
Currently there's no way to easily decrypt an encrypted field, or vice versa. Just adding a field to `excludeFromEncryption` won't work, and could lead to a data loss.

Related issues:
- https://github.com/joegoldbeck/mongoose-encryption/issues/83
- https://github.com/joegoldbeck/mongoose-encryption/issues/48

This recepie from #48:

> If you update the options so that the field will no longer be encrypted, then when you find a document, it will still be decrypted, but when you go to save it again, it will remain unencrypted and be persisted as cleartext.

does not work, since #22 has changed the way decrypted data assigned to document: now only fields listed in `encryptedFields` variable assigned, any extra data is ignored.

Using proposed version, encrypted fields can be changed seamlessly when all records have `_cf` list. Existing records will continue to work, but updating an existing record won't change its encryption rules. If existing records need to be updated according to new encryption rules, `updateCf` method can be used:

```
const docs = await NewModel.find({})
for (doc of docs) {
  doc.updateCf()
  await doc.save()
}
```
The `updateCf` method also can be used to init `_cf` list on existing records.

### How it works
Encrypted fields list stored to `_cf` property of secret part (`_ct._cf`).

On decrypt, fields listed in `_cf` will be assigned to data, additionally `_cf` list is assigned to `Document` instance, to use in following encryption.

Encrypt uses fields list from `_cf` property of `Document` instance if it's set, otherwise current schema's list is used.

On executing `updateCf`, fields that are no longer in current schema's list are marked modified (to force its update by mongoose). Current schema's list is assigned to `_cf` property of `Document` instance (to force new encryption rules).

New `cfMode` option is added:

- `store` (default): Set `_cf` if it's not set using current schema's list
- `require`: Same as `store`, but throws an error if record does not contain `_cf`
- `disable`: Disable new function

### Backward compatibility and default behavior
PR keeps backward compatibility in regular cases.

Additionaly, new features can be disabled entirely by setting `cfMode: 'disable'` in plugin's options:
```
MySchema.plugin(encrypt, {
    encryptionKey,
    signingKey,
    cfMode: 'disable',
})
```

By default `cfMode` is set to `store`. This will keep backward compatibility for existing users, and add `_cf` to all new data. 



