### PR TITLE
Store encrypted fields list to _ct._cf #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ You cannot change the following options once you've started using them for a col
 - `collectionId`
 
 Additionally, by default (see `cfMode` section below), you cannot change plugin options in a way that affects list of encrypted fields:
-- `encryptedFields` cannot not be changed
-- `excludeFromEncryption` cannot not be changed
+- `encryptedFields` cannot be changed
+- `excludeFromEncryption` cannot be changed
 - You cannot add or remove indexes on fields that are not explicitly excluded with `excludeFromEncryption` or `encryptedFields` option (index configuration change is allowed).
 
 ## `cfMode`: Storing list of encrypted fields

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -420,17 +420,22 @@ var mongooseEncryption = function(schema, options) {
         cb();
     };
 
-    schema.methods.decryptData = function(data) {
-        var ct, cf, ctWithIV, decipher, iv, idString, decryptedObject, decryptedObjectJSON, decipheredVal;
-        if (data._ct) {
-            ctWithIV = data._ct.hasOwnProperty('buffer') ? data._ct.buffer : data._ct;
-            iv = ctWithIV.slice(VERSION_LENGTH, VERSION_LENGTH + IV_LENGTH);
-            ct = ctWithIV.slice(VERSION_LENGTH + IV_LENGTH, ctWithIV.length);
+    schema.methods.decryptCt = function(_ct) {
+        var ct, ctWithIV, decipher, iv, decryptedObjectJSON;
+        ctWithIV = _ct.hasOwnProperty('buffer') ? _ct.buffer : _ct;
+        iv = ctWithIV.slice(VERSION_LENGTH, VERSION_LENGTH + IV_LENGTH);
+        ct = ctWithIV.slice(VERSION_LENGTH + IV_LENGTH, ctWithIV.length);
 
-            decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, encryptionKey, iv);
+        decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, encryptionKey, iv);
+        decryptedObjectJSON = decipher.update(ct, undefined, 'utf8') + decipher.final('utf8');
+        return JSON.parse(decryptedObjectJSON);
+    };
+    
+    schema.methods.decryptData = function(data) {
+        var cf, idString, decryptedObject, decipheredVal;
+        if (data._ct) {
             try {
-                decryptedObjectJSON = decipher.update(ct, undefined, 'utf8') + decipher.final('utf8');
-                decryptedObject = JSON.parse(decryptedObjectJSON);
+                decryptedObject = schema.methods.decryptCt(data._ct);
             } catch (err) {
                 if (data._id) {
                     idString = data._id.toString();

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -162,7 +162,7 @@ var mongooseEncryption = function(schema, options) {
         throw new Error('Schema cannot use _cf field when options.cfMode is not disabled');
     }
     if (cfMode === 'maintenance') {
-        throw new Error('options.cfMode is set to maintenance');
+        console.warn('options.cfMode is set to maintenance');
     }
 
 

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -36,6 +36,10 @@ if(semver.lt(mongoose.version, '5.0.0')){
 }
 
 /**
+ * @typedef {'disable'|'maintenance'|'require'} CfMode
+ */
+
+/**
  * Mongoose encryption plugin
  * @module mongoose-encryption
  *
@@ -51,11 +55,12 @@ if(semver.lt(mongoose.version, '5.0.0')){
  * @param      {boolean}    [options.requireAuthenticationCode=true]  Whether documents without an authentication code are valid
  * @param      {boolean}    [options.decryptPostSave=true]  Whether to automatically decrypt documents in the application after saving them (faster if false)
  * @param      {string}     [options.collectionId]  If you update the Model name of the schema, this should be set to its original name
+ * @param      {CfMode}     [options.cfMode='disable']
  * @return     {undefined}
  */
 
 var mongooseEncryption = function(schema, options) {
-    var encryptedFields, excludedFields, authenticatedFields, encryptionKey, signingKey, path;
+    var encryptedFields, excludedFields, authenticatedFields, encryptionKey, signingKey, path, cfMode;
 
     _.defaults(options, {
         middleware: true, // allow for skipping middleware with false
@@ -100,6 +105,10 @@ var mongooseEncryption = function(schema, options) {
         options.excludeFromEncryption = options.exclude;
         console.warn('options.fields has been deprecated. please use options.excludeFromEncryption');
     }
+
+
+    /** Decryption Options */
+    cfMode = options.cfMode || 'disable';
 
 
     /** Encryption Options */
@@ -147,6 +156,13 @@ var mongooseEncryption = function(schema, options) {
                 type: Buffer
             }
         });
+    }
+
+    if (cfMode !== 'disable' && schema.paths._cf) {
+        throw new Error('Schema cannot use _cf field when options.cfMode is not disabled');
+    }
+    if (cfMode === 'maintenance') {
+        throw new Error('options.cfMode is set to maintenance');
     }
 
 
@@ -264,6 +280,10 @@ var mongooseEncryption = function(schema, options) {
         schema.pre('save', function(next) {
             var that = this;
             if (this.isNew || this.isSelected('_ct') ){
+                if (cfMode !== 'disable' && this.isNew && !this._cf) {
+                    this._cf = encryptedFields;
+                }
+
                 that.encrypt(function(err){
                     if (err) {
                         next(err);
@@ -321,12 +341,22 @@ var mongooseEncryption = function(schema, options) {
 
         // generate random iv
         crypto.randomBytes(IV_LENGTH, function(err, iv) {
-            var cipher, jsonToEncrypt, objectToEncrypt;
+            var cf, cipher, jsonToEncrypt, objectToEncrypt;
             if (err) {
                 return cb(err);
             }
+
+            if (cfMode === 'disable') {
+                cf = encryptedFields;
+            } else {
+                cf = that._cf || encryptedFields;
+            }
+
             cipher = crypto.createCipheriv(ENCRYPTION_ALGORITHM, encryptionKey, iv);
-            objectToEncrypt = pick(that, encryptedFields, {excludeUndefinedValues: true});
+            objectToEncrypt = pick(that, cf, {excludeUndefinedValues: true});
+            if (cfMode !== 'disable') {
+                objectToEncrypt._cf = cf.join(',');
+            }
 
             jsonToEncrypt = JSON.stringify(objectToEncrypt);
 
@@ -343,11 +373,41 @@ var mongooseEncryption = function(schema, options) {
             that._ct = Buffer.concat([VERSION_BUF, iv, Buffer.from(encrypted, 'utf8')]);
 
             // remove encrypted fields from cleartext
-            encryptedFields.forEach(function(field){
-                setFieldValue(that, field, undefined);
+            cf.forEach(function(field){
+                that.set(field, undefined);
             });
 
             cb(null);
+        });
+    };
+
+    schema.methods.updateCf = function () {
+        var that = this, extractedFields;
+
+        if(this._ct){
+            return cb(new Error('Cf update failed: document is not deciphered'));
+        }
+
+        extractedFields = _.difference(that._cf, encryptedFields);
+        extractedFields.forEach(field => that.markModified(field));
+
+        that._cf = encryptedFields;
+
+        _.keys(this.schema.paths).forEach(function (path) {
+            if (path === '_id' || path === '__v') {
+                return;
+            }
+    
+            var nestedDoc = dotty.get(that, path);
+            var docs = _.isArray(nestedDoc) ? nestedDoc : [nestedDoc];
+    
+            if (docs && docs[0] && isEmbeddedDocument(docs[0])) {
+                docs.forEach(function (subDoc) {
+                    if (_.isFunction(subDoc.updateCf)) {
+                        subDoc.updateCf();
+                    }
+                });
+            }
         });
     };
 
@@ -361,7 +421,7 @@ var mongooseEncryption = function(schema, options) {
     };
 
     schema.methods.decryptData = function(data) {
-        var ct, ctWithIV, decipher, iv, idString, decryptedObject, decryptedObjectJSON, decipheredVal;
+        var ct, cf, ctWithIV, decipher, iv, idString, decryptedObject, decryptedObjectJSON, decipheredVal;
         if (data._ct) {
             ctWithIV = data._ct.hasOwnProperty('buffer') ? data._ct.buffer : data._ct;
             iv = ctWithIV.slice(VERSION_LENGTH, VERSION_LENGTH + IV_LENGTH);
@@ -380,7 +440,17 @@ var mongooseEncryption = function(schema, options) {
                 throw new Error('Error parsing JSON during decrypt of ' + idString + ': ' + err);
             }
 
-            encryptedFields.forEach(function(field) {
+            if (cfMode === 'require' && !decryptedObject._cf) {
+                throw new Error('Cipher fields list _cf is required, but not found in cipher text');
+            } else if (cfMode !== 'disable' &&  decryptedObject._cf) {
+                cf = decryptedObject._cf.split(',');
+            }
+            
+            if (!cf) {
+                cf = encryptedFields;
+            }
+
+            cf.forEach(function(field) {
                 decipheredVal = mpath.get(field, decryptedObject);
 
                 //JSON.parse returns {type: "Buffer", data: Buffer} for Buffers
@@ -394,6 +464,10 @@ var mongooseEncryption = function(schema, options) {
 
             data._ct = undefined;
             data._ac = undefined;
+
+            if (cfMode !== 'disable') {
+                this._cf = cf;
+            }
         }
     };
 

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -244,7 +244,7 @@ var mongooseEncryption = function(schema, options) {
                     }
                 }
                 if (this.isSelected('_ct')){
-                    this.decryptSync.call(data);
+                    this.decryptData(data);
                 }
             } catch (e) {
                 err = e;
@@ -360,11 +360,10 @@ var mongooseEncryption = function(schema, options) {
         cb();
     };
 
-    schema.methods.decryptSync = function() {
-        var that = this;
+    schema.methods.decryptData = function(data) {
         var ct, ctWithIV, decipher, iv, idString, decryptedObject, decryptedObjectJSON, decipheredVal;
-        if (this._ct) {
-            ctWithIV = this._ct.hasOwnProperty('buffer') ? this._ct.buffer : this._ct;
+        if (data._ct) {
+            ctWithIV = data._ct.hasOwnProperty('buffer') ? data._ct.buffer : data._ct;
             iv = ctWithIV.slice(VERSION_LENGTH, VERSION_LENGTH + IV_LENGTH);
             ct = ctWithIV.slice(VERSION_LENGTH + IV_LENGTH, ctWithIV.length);
 
@@ -373,8 +372,8 @@ var mongooseEncryption = function(schema, options) {
                 decryptedObjectJSON = decipher.update(ct, undefined, 'utf8') + decipher.final('utf8');
                 decryptedObject = JSON.parse(decryptedObjectJSON);
             } catch (err) {
-                if (this._id) {
-                    idString = this._id.toString();
+                if (data._id) {
+                    idString = data._id.toString();
                 } else {
                     idString = 'unknown';
                 }
@@ -387,18 +386,20 @@ var mongooseEncryption = function(schema, options) {
                 //JSON.parse returns {type: "Buffer", data: Buffer} for Buffers
                 //https://nodejs.org/api/buffer.html#buffer_buf_tojson
                 if(_.isObject(decipheredVal) && decipheredVal.type === "Buffer"){
-                    setFieldValue(that, field, decipheredVal.data);
+                    setFieldValue(data, field, decipheredVal.data);
                 }else {
-                    setFieldValue(that, field, decipheredVal);
+                    setFieldValue(data, field, decipheredVal);
                 }
             });
 
-            this._ct = undefined;
-            this._ac = undefined;
+            data._ct = undefined;
+            data._ac = undefined;
         }
     };
 
-
+    schema.methods.decryptSync = function() {
+        return this.decryptData(this)
+    };
 
 
     /** Authentication Instance Methods */

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -384,6 +384,10 @@ var mongooseEncryption = function(schema, options) {
     schema.methods.updateCf = function () {
         var that = this, extractedFields;
 
+        if (cfMode === 'disable') {
+            throw new Error(`Cannot update cf: cf is disabled`);
+        }
+
         if(this._ct){
             return cb(new Error('Cf update failed: document is not deciphered'));
         }

--- a/test/encrypt.coffee
+++ b/test/encrypt.coffee
@@ -398,7 +398,7 @@ describe 'EncryptedModel.find()', ->
   before (done) ->
     @sandbox = sinon.sandbox.create()
     @sandbox.spy BasicEncryptedModel.prototype, 'authenticateSync'
-    @sandbox.spy BasicEncryptedModel.prototype, 'decryptSync'
+    @sandbox.spy BasicEncryptedModel.prototype, 'decryptData'
     simpleTestDoc3 = new BasicEncryptedModel
       text: 'Unencrypted text'
       bool: true
@@ -414,7 +414,7 @@ describe 'EncryptedModel.find()', ->
 
   beforeEach ->
     BasicEncryptedModel.prototype.authenticateSync.reset()
-    BasicEncryptedModel.prototype.decryptSync.reset()
+    BasicEncryptedModel.prototype.decryptData.reset()
 
   after (done) ->
     @sandbox.restore()
@@ -458,13 +458,13 @@ describe 'EncryptedModel.find()', ->
       done()
     return
 
-  it 'should have called authenticateSync then decryptSync', (done) ->
+  it 'should have called authenticateSync then decryptData', (done) ->
     BasicEncryptedModel.findById simpleTestDoc3._id, (err, doc) ->
       assert.equal err, null
       assert.ok doc
       assert.equal doc.authenticateSync.callCount, 1
-      assert.equal doc.decryptSync.callCount, 1
-      assert doc.authenticateSync.calledBefore doc.decryptSync, 'authenticated before decrypted'
+      assert.equal doc.decryptData.callCount, 1
+      assert doc.authenticateSync.calledBefore doc.decryptData, 'authenticated before decrypted'
       done()
     return
 


### PR DESCRIPTION
### TL;DR

Remember the time when you needed to decrypt an encrypted field? Or maybe you needed to move a field to encryption? 
Remember the pain?

1) Run once:
```
const updateCtAll = async () => {
    for await (const doc of Model.find()) {
        doc.updateCt()
        await doc.save()
    }
}
```

2) Set `cfMode: 'require'` option in plugin configuration

And now you can change schema and plugin options to tweak list of encrypted fields.
Existing documents will work transparently, because each document now includes its own list of encrypted fields!

Keep in mind, that existing documents keep their lists of encrypted fields. So, updating a document won't automaticaly "reconfigure" its ancryption. But you can call `doc.updateCt()` and document will be reconfigured!

So, if you need to add an index over previously encrypted field (or just decrypt a field), or to encrypt another field, you just do it in schema's config. And when you need to reconfigure existing documents, just run something like `updateCtAll` again.

See more info in new Readme sections: https://github.com/jenyatra/mongoose-encryption/tree/cf#changing-options
___________________________________________

Better to analyze this PR by commits: https://github.com/joegoldbeck/mongoose-encryption/pull/109/commits,
commentary provided.
___________________________________________

### PR goals:
1. Protect from data loss caused by changes in encrypted fields list 
2. Provide a way to change encrypted fields list in controlled manner


### Data loss example:
Data loss occurs when schema is changed in a way that affects encrypted fields list, such as adding an index on a field:

```
const Schema1 = new Schema({
    my_data: { type: String },
})

const Schema2 = new Schema({
    my_data: {  type: String, index: true }
})

// Adding index to the Schema2 will lead to exclusion of `my_data` field from `encryptedFields` list.
// Because of that, `my_data` field won't be populated from `_ct` on next instantiation,
// Saving document with non-populated `my_data` field will overwrite `_ct`, and data will be lost.

// Same problem occurs when fields excluded from encryption other ways,
// such as using `excludeFromEncryption` option.
```


### Tests repo:
More detailed examples (ready to run): https://github.com/jenyatra/mongoose-encryption-test
```
git clone https://github.com/jenyatra/mongoose-encryption-test
cd mongoose-encryption-test
npm install
echo "MONGO_URI=mongodb://localhost:27017/$SET YOUR TEST DB HERE$" > .env
```
Available tests:

- `npm run fields_change`: Test changes in encrypted fields list for root fields
- `npm run fields_change:cf`: Previous test run by proposed version
- `npm run fields_change_deep`:  Same for nested fields (type: Mixed, dot notation)
- `npm run fields_change_deep:cf`:  Previous test run by proposed version
- `npm run fields_change_nested`: Test for nested docs (type: new Schema)
- `npm run fields_change_nested:cf`: Previous test run by proposed version
- `npm run init_cf`: Example of _cf initialization on existing data


### Addressing issues on changing encryption fields list
Currently there's no way to easily decrypt an encrypted field, or vice versa. Just adding a field to `excludeFromEncryption` won't work, and could lead to a data loss.

Related issues:
- https://github.com/joegoldbeck/mongoose-encryption/issues/83
- https://github.com/joegoldbeck/mongoose-encryption/issues/48

Using new features proposed in this PR, Schema and plugin options related to encryption fields list can be changed seamlessly.

### How it works
Encrypted fields list stored to `_cf` property of secret part (`_ct._cf`).

On decrypt, fields listed in `_cf` will be assigned to data, additionally `_cf` list is assigned to `Document` instance, to use in following encryption.

Encrypt uses fields list from `_cf` property of `Document` instance if it's set, otherwise current schema's list is used.

On executing `updateCf`, fields that are no longer in current schema's list are marked modified (to force its update by mongoose). Current schema's list is assigned to `_cf` property of `Document` instance (to force new encryption rules).

New `cfMode` option is added:

- `disable` (default): Disable new function
- `require`: requires `_cf` list to operate on existing documents
- `maintenance`: uses `_cf` list when set on a document, otherwise uses Schema's `encryptedFields`

### Backward compatibility and default behavior
PR keeps backward compatibility in regular cases.
New features are disabled by default.



