### PR TITLE
Check if excludeFromEncryption doesnt contain nested fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ To exclude additional fields (other than _id and indexed fields), pass the `excl
 userSchema.plugin(encrypt, { encryptionKey: encKey, signingKey: sigKey, excludeFromEncryption: ['age'] });
 ```
 
+Note: only Schema's root fields can be excluded this way.
+
 ### Encrypt Only Certain Fields
 
 You can also specify exactly which fields to encrypt with the `encryptedFields` option. This overrides the defaults and all other options.

--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -101,6 +101,13 @@ var mongooseEncryption = function(schema, options) {
         console.warn('options.fields has been deprecated. please use options.excludeFromEncryption');
     }
 
+    if (options.excludeFromEncryption) {
+        options.excludeFromEncryption.forEach(function (field) {
+            if (field.indexOf('.') !== -1) {
+                throw new Error(`excludeFromEncryption cannot be used for nested fields. Use nested Schemas instead.`)
+            }
+        })
+    }
 
     /** Encryption Options */
 

--- a/test/encrypt.coffee
+++ b/test/encrypt.coffee
@@ -834,6 +834,14 @@ describe '"excludeFromEncryption" option', ->
         assert.propertyVal excludeEncryptedDoc, 'idx', 'Indexed'
         done()
 
+  it 'should throw when an excludeFromEncryption contains a nested path', () ->
+    ExcludeEncryptedModelSchema = mongoose.Schema
+      num: type: Number
+      nested: type: Object
+
+    assert.throws ( -> ExcludeEncryptedModelSchema.plugin encrypt, encryptionKey: encryptionKey, signingKey: signingKey, collectionId: 'ExcludeEncrypted', excludeFromEncryption: ['num', 'nested.value'])
+
+    
 describe '"decryptPostSave" option', ->
   before ->
     HighPerformanceModelSchema = mongoose.Schema


### PR DESCRIPTION
Current behavior of `excludeFromEncryption` option is that the library doesn't support nested fields to be excluded.

Currently any field that is not in the Schema's root will do nothing here:
https://github.com/joegoldbeck/mongoose-encryption/blob/c3dd81aaf810c515228378b6ab75932df16493c1/lib/plugins/mongoose-encryption.js#L111
```
 encryptedFields = _.chain(schema.paths)
...
            .pluck('path') // get path name
            .difference(excludedFields) // exclude excluded fields
```

This PR adds a note in Readme, and detects if excludeFromEncryption option contains nested fields.

This PR is cruel: it will throw an error, if user tries to exclude a nested field. Maybe we should only generate a warning instead?