### PR TITLE
Fix errors with encrypted subdoc arrays on Mongoose v6

### DIFF
--- a/lib/plugins/mongoose-encryption.js
+++ b/lib/plugins/mongoose-encryption.js
@@ -345,6 +345,10 @@ var mongooseEncryption = function(schema, options) {
             // remove encrypted fields from cleartext
             encryptedFields.forEach(function(field){
                 setFieldValue(that, field, undefined);
+                // prevent conflict errors due to array change tracking in Mongoose 6
+                if (that.schema.paths[field].$isMongooseArray) {
+                    that.unmarkModified(field);
+                }
             });
 
             cb(null);


### PR DESCRIPTION
As of Mongoose v6, encrypted subdocument arrays lead to the following
error when updating an existing document:

> MongoServerError: Updating the path '…' would create a conflict at '…'

This change circumvents the problem by marking the corresponding schema
paths as unmodified (which should be safe, since those encrypted fields
are not meant to be stored anyway).

Fixes #105